### PR TITLE
Added ability to link solr metadata fields to corresponding object

### DIFF
--- a/includes/config.inc
+++ b/includes/config.inc
@@ -254,7 +254,7 @@ function islandora_solr_metadata_config_form($form, &$form_state, $configuration
  */
 function islandora_solr_metadata_config_form_validate($form, $form_state) {
   if ($form_state['triggering_element']['#name'] == 'islandora-solr-metadata-add-field') {
-    module_load_include('inc', 'islandora_solr_search', 'includes/luke');
+    module_load_include('inc', 'islandora_solr', 'includes/luke');
     $solr_luke = islandora_solr_get_luke();
     $luke_fields = array_keys($solr_luke['fields']);
 
@@ -299,7 +299,7 @@ function islandora_solr_metadata_config_form_validate($form, $form_state) {
   if ($form_state['triggering_element']['#value'] == 'Save configuration') {
     $solr_field = $form_state['values']['islandora_solr_metadata_fields']['description_fieldset']['available_solr_fields'];
     if (!empty($solr_field)) {
-      module_load_include('inc', 'islandora_solr_search', 'includes/luke');
+      module_load_include('inc', 'islandora_solr', 'includes/luke');
       $solr_luke = islandora_solr_get_luke();
       $luke_fields = array_keys($solr_luke['fields']);
       if (!in_array($solr_field, $luke_fields)) {

--- a/includes/config.inc
+++ b/includes/config.inc
@@ -544,9 +544,30 @@ function islandora_solr_metadata_config_field_form($form, &$form_state, $config_
       '#type' => 'radios',
       '#title' => t('Link target'),
       '#options' => array('SOLR' => t('SOLR search'),
-                          'pathauto' => t('Link to URL alias that matches field\'s original value.')
+                          'islandora_url' => t('Link to /islandora/object/{PID} matching object value.'),
+                          'pathauto' => t('Custom path based on object tokens.')
       ),
       '#default_value' => $get_default(array('link_options', 'link_target'), 'SOLR'),
+    ),
+    'link_target_options' => array(
+      '#type' => 'fieldset',
+      '#title' => 'Custom path',
+      '#collapsible' => FALSE,
+      'link_target_pattern' => array(
+        '#type' => 'textfield',
+        '#title' => t('Path'),
+        '#description' => t('This value must contain "%1" for token replacement.  For example: ') . '<code>/group/department/%1</code>',
+        '#size' => 45,
+        '#default_value' => $get_default(array('link_options', 'link_target_options', 'link_target_pattern'), ''),
+      ),
+      'link_target_field' => array(
+        '#type' => 'textfield',
+        '#title' => t('Replace %1 token with'),
+        '#description' => t('Field used for the $1 token.  This value will be normalized and inserted where the %1 appears for the path pattern.'),
+        '#size' => 45,
+        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+        '#default_value' => $get_default(array('link_options', 'link_target_options', 'link_target_field'), ''),
+      ),
     ),
   );
   // Add in truncation fields for metadata field.

--- a/includes/config.inc
+++ b/includes/config.inc
@@ -512,6 +512,46 @@ function islandora_solr_metadata_config_field_form($form, &$form_state, $config_
     '#description' => t('Should each value for this field be linked to a search to find objects with the value in this field?'),
     '#default_value' => $get_default('hyperlink', FALSE),
   );
+  $link_target_options = array('SOLR' => t('SOLR search'));
+  if (module_exists('pathauto') == TRUE) {
+    $link_target_options['pathauto'] = t('Link to URL alias that matches field\'s original value.');
+  }
+
+  $set['link_options'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Link options'),
+    '#collapsed' => TRUE,
+    '#collapsible' => TRUE,
+    'link_text' => array(
+      '#type' => 'radios',
+      '#title' => 'Link Text',
+      '#options' => array(
+        'default' => t('Default field value'),
+        'otherfield' => t('Display alternate field value')
+      ),
+      '#default_value' => $get_default(array('link_options', 'link_text'), 'default'),
+    ),
+    'link_text_options' => array(
+      '#type' => 'fieldset',
+      '#title' => 'Alternate field value',
+      '#collapsible' => FALSE,
+      'link_text_text' => array(
+        '#type' => 'textfield',
+        '#title' => t('Alternate field value'),
+        '#description' => t('Value from which field to use for link text.'),
+        '#size' => 45,
+        '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+        '#default_value' => $get_default(array('link_options', 'link_text_options', 'link_text_text'), ''),
+      ),
+    ),
+    'link_target' => array(
+      '#type' => 'radios',
+      '#title' => t('Link target'),
+      '#options' => $link_target_options,
+      '#default_value' => $get_default(array('link_options', 'link_target'), 'SOLR'),
+    ),
+  );
+
   // Add in truncation fields for metadata field.
   $truncation_config = array(
     'default_values' => array(
@@ -624,3 +664,5 @@ function islandora_solr_metadata_add_truncation_to_form(&$form, $field_config) {
     ),
   );
 }
+
+

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -80,7 +80,22 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
  */
 function template_process_islandora_solr_metadata_display(array &$variables) {
   $variables['found'] = islandora_solr_metadata_query_fields($variables['islandora_object'], $variables['solr_fields']);
-
+  // Remove empty values.
+  if ($variables['found']) {
+    foreach ($variables['solr_fields'] as $solr_field=>$solr_field_array) {
+      if (isset($solr_field_array['value']) && is_array($solr_field_array['value'])) {
+        foreach ($solr_field_array['value'] as $k=>$val) {
+          if (trim($val) == '') {
+            unset($variables['solr_fields'][$solr_field]['value'][$k]);
+          }
+        }
+        // If no values left, also remove the field / label.
+        if (count($solr_field_array['value']) < 1) {
+          unset($variables['solr_fields'][$solr_field]);
+        }
+      }
+    }
+  }
   $variables['not_found_message'] = t('Document not present in Solr while generating the metadata display for @id. Try !reloading the page, or contact an administrator if this issue persists.', array(
     '@id' => $variables['islandora_object']->id,
     '!reloading' => '<a href="" onclick="window.location.reload(true)">' . t('reloading') . '</a>',
@@ -199,7 +214,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // modified to get around a bug in PHP 5.3.3 when used on CentOS 6.6,
         // otherwise the calling function doesn't maintain a reference to the
         // original value and it becomes a copy.
-        $get_display_value = function ($original_value) use ($solr_field, &$solr_fields) {
+        $get_display_value = function ($original_value) use ($solr_field, &$solr_fields, $object) {
           $value = $original_value;
           $field_config = (is_array($solr_fields[$solr_field]) ? $solr_fields[$solr_field] : array()) + array(
             'hyperlink' => 0,
@@ -227,12 +242,13 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
           if (is_callable($field_config['formatter'])) {
             $value = call_user_func($field_config['formatter'], $value);
           }
+
           if ($field_config['hyperlink'] == 1 && trim($value)) {
             $use_value = $value;
             if ($link_options = drupal_array_get_nested_value($field_config, array('link_options'))) {
               if (isset($link_options['link_text']) && $link_options['link_text'] == 'otherfield') {
-                $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
-
+                $target_object = islandora_object_load(str_replace('info:fedora/', '', $value)); 
+	
                 $site = _get_site_from_config();
                 $target_sites_rel = $target_object->relationships->get(NULL, 'isMemberOfSite');
                 $target_sites = array();
@@ -242,7 +258,6 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                   }
                 }
                 if ($site <> '' && array_search($site, $target_sites) === FALSE) {
-                  unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
                   return ;
                 }
 

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -248,20 +248,19 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
             if ($link_options = drupal_array_get_nested_value($field_config, array('link_options'))) {
               if (isset($link_options['link_text']) && $link_options['link_text'] == 'otherfield') {
                 $target_object = islandora_object_load(str_replace('info:fedora/', '', $value)); 
-	
-                $site = _get_site_from_config();
-                $target_sites_rel = $target_object->relationships->get(NULL, 'isMemberOfSite');
-                $target_sites = array();
-                foreach ($target_sites_rel as $tar) {
-                  if (isset($tar['object']['value'])) {
-                    $target_sites[] = 'info:fedora/' . $tar['object']['value'];
+                if (is_object($target_object)) {
+                  $site = _get_site_from_config();
+                  $target_sites_rel = $target_object->relationships->get(NULL, 'isMemberOfSite');
+                  $target_sites = array();
+                  foreach ($target_sites_rel as $tar) {
+                    if (isset($tar['object']['value'])) {
+                      $target_sites[] = 'info:fedora/' . $tar['object']['value'];
+                    }
                   }
-                }
-                if ($site <> '' && array_search($site, $target_sites) === FALSE) {
-                  return ;
-                }
+                  if ($site <> '' && array_search($site, $target_sites) === FALSE) {
+                    return ;
+                  }
 
-                if ($target_object) {
                   $use_target = 'islandora/object/' . $target_object->id;
                   $use_value = ($link_options['link_text_options']['link_text_text']) ?
                     _get_SOLR_field_value($target_object->id, $link_options['link_text_options']['link_text_text']) : $target_object->label;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -72,7 +72,6 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
       'value' => array(),
     );
   }
-
   $variables['parent_collections'] = islandora_get_parents_from_rels_ext($object);
 }
 
@@ -81,6 +80,7 @@ function template_preprocess_islandora_solr_metadata_display(array &$variables) 
  */
 function template_process_islandora_solr_metadata_display(array &$variables) {
   $variables['found'] = islandora_solr_metadata_query_fields($variables['islandora_object'], $variables['solr_fields']);
+
   $variables['not_found_message'] = t('Document not present in Solr while generating the metadata display for @id. Try !reloading the page, or contact an administrator if this issue persists.', array(
     '@id' => $variables['islandora_object']->id,
     '!reloading' => '<a href="" onclick="window.location.reload(true)">' . t('reloading') . '</a>',
@@ -191,7 +191,6 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
     $query_processor->executeQuery(FALSE);
     if ($query_processor->islandoraSolrResult['response']['numFound'] > 0) {
       $solr_results_doc = $query_processor->islandoraSolrResult['response']['objects']['0']['solr_doc'];
-
       // Ensure we only provide results for what is specified.
       $constrained_results = array_intersect_key($solr_results_doc, $solr_fields);
 
@@ -229,6 +228,42 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
             $value = call_user_func($field_config['formatter'], $value);
           }
           if ($field_config['hyperlink'] == 1 && trim($value)) {
+            if ($link_options = drupal_array_get_nested_value($field_config, array('link_options'))) {
+              $use_value = $value;
+              if (isset($link_options['link_text']) && $link_options['link_text'] == 'otherfield') {
+                $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
+                if ($target_object) {
+                  $use_target = 'islandora/object/' . $target_object->id;
+                  $use_value = $target_object->label;
+                } else {
+                  $use_target = '';
+                  $use_value = 'test';
+                }
+              }
+              if (!isset($link_options['link_target']) || $link_options['link_target'] == 'SOLR') {
+                if (variable_get('islandora_solr_metadata_omit_empty_values', FALSE) && !trim($value)) {
+                  // Avoid generating markup (throwing off the "empty" check).
+                  // Will get stripped out later.
+                  return;
+                }
+                $solr_query = format_string('!field:!value', array(
+                  '!field' => $solr_field,
+                  '!value' => islandora_solr_facet_escape($original_value),
+                ));
+                return l($use_value, 'islandora/search', array(
+                  "query" => array(
+                    "type" => "dismax",
+                    "f" => array(
+                      $solr_query,
+                    ),
+                  ),
+                ));
+              }
+              else {
+                // Based on the config, see what the target is.
+                return ($use_target) ? l($use_value, $use_target) : $use_value;
+              }
+            }
             if (variable_get('islandora_solr_metadata_omit_empty_values', FALSE) && !trim($value)) {
               // Avoid generating markup (throwing off the "empty" check).
               // Will get stripped out later.
@@ -293,3 +328,4 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
     }
   }
 }
+

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -342,38 +342,6 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
   }
 }
 
-/** 
- * Helper function to derive the site value from the islandora_solr_base_filter value.  Does not handle more than
- * one site value in the base filter.
- */
-function _get_site_from_config() {
-  $base_filter = variable_get('islandora_solr_base_filter');
-  // look for the value for RELS_EXT_isMemberOfSite_uri_ms 
-  $and_filters = explode(" AND ", $base_filter);
-  $final_filters = array();
-  foreach ($and_filters as $exploded) {
-    $nl_exploded = explode("\r\n", $exploded);
-    if (is_array($nl_exploded)) {
-      foreach ($nl_exploded as $nl_element) {
-        $final_filters[] = trim($nl_element);
-      }
-    }
-    else {
-      $final_filters[] = $nl_exploded;
-    }
-  }
-  $found_filter = '';
-  foreach ($final_filters as $filter) { 
-    if (strstr($filter, 'RELS_EXT_isMemberOfSite_uri_ms') <> '') {
-      $found_filter = $filter;
-    }  
-  }
-  if ($found_filter) { 
-    $site = stripslashes(str_replace(array('"', 'RELS_EXT_isMemberOfSite_uri_ms:'), '', $found_filter));
-    return $site;
-  }
-}
-
 
 /**
  * Helper function to get a SOLR value for a given PID.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -262,8 +262,8 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                   }
                   $use_target = (isset($link_options['link_target']) && $link_options['link_target'] == 'pathauto') ? 
                     str_replace('%1', 
-                                str_replace("+", 
-                                            "-", 
+                                str_replace(array("+", "."), 
+                                            array("-", ""), 
                                             urlencode(strtolower(trim(_get_SOLR_field_value($target_object->id, $link_options['link_target_options']['link_target_field']))))), 
                                 $link_options['link_target_options']['link_target_pattern']) : 
                     'islandora/object/' . $target_object->id;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -349,15 +349,19 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
 function _get_site_from_config() {
   $base_filter = variable_get('islandora_solr_base_filter');
   // look for the value for RELS_EXT_isMemberOfSite_uri_ms 
-  $filters = explode("\r\n", $base_filter);
+  $final_filters = explode(" AND ", $base_filter);
+//  $final_filters = array();
+/*  foreach ($filters as $exploded) {
+    $final_filters = array_merge(explode("\r\n", $exploded);
+  } */
   $found_filter = '';
-  foreach ($filters as $filter) { 
+  foreach ($final_filters as $filter) { 
     if (strstr($filter, 'RELS_EXT_isMemberOfSite_uri_ms') <> '') {
       $found_filter = $filter;
     }  
   }
   if ($found_filter) { 
-    $site = str_replace(array('"', 'RELS_EXT_isMemberOfSite_uri_ms:'), '', $found_filter);
+    $site = stripslashes(str_replace(array('"', 'RELS_EXT_isMemberOfSite_uri_ms:'), '', $found_filter));
     return $site;
   }
 }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -349,11 +349,19 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
 function _get_site_from_config() {
   $base_filter = variable_get('islandora_solr_base_filter');
   // look for the value for RELS_EXT_isMemberOfSite_uri_ms 
-  $final_filters = explode(" AND ", $base_filter);
-//  $final_filters = array();
-/*  foreach ($filters as $exploded) {
-    $final_filters = array_merge(explode("\r\n", $exploded);
-  } */
+  $and_filters = explode(" AND ", $base_filter);
+  $final_filters = array();
+  foreach ($and_filters as $exploded) {
+    $nl_exploded = explode("\r\n", $exploded);
+    if (is_array($nl_exploded)) {
+      foreach ($nl_exploded as $nl_element) {
+        $final_filters[] = trim($nl_element);
+      }
+    }
+    else {
+      $final_filters[] = $nl_exploded;
+    }
+  }
   $found_filter = '';
   foreach ($final_filters as $filter) { 
     if (strstr($filter, 'RELS_EXT_isMemberOfSite_uri_ms') <> '') {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -360,3 +360,34 @@ function _get_SOLR_field_value($pid, $field) {
   }
 }
 
+/**
+ * Helper function to derive the site value from the islandora_solr_base_filter value.  Does not handle more than
+ * one site value in the base filter.
+ */
+function _get_site_from_config() {
+  $base_filter = variable_get('islandora_solr_base_filter');
+  // look for the value for RELS_EXT_isMemberOfSite_uri_ms
+  $and_filters = explode(" AND ", $base_filter);
+  $final_filters = array();
+  foreach ($and_filters as $exploded) {
+    $nl_exploded = explode("\r\n", $exploded);
+    if (is_array($nl_exploded)) {
+      foreach ($nl_exploded as $nl_element) {
+        $final_filters[] = trim($nl_element);
+      }
+    }
+    else {
+      $final_filters[] = $nl_exploded;
+    }
+  }
+  $found_filter = '';
+  foreach ($final_filters as $filter) {
+    if (strstr($filter, 'RELS_EXT_isMemberOfSite_uri_ms') <> '') {
+      $found_filter = $filter;
+    }
+  }
+  if ($found_filter) {
+    $site = stripslashes(str_replace(array('"', 'RELS_EXT_isMemberOfSite_uri_ms:'), '', $found_filter));
+    return $site;
+  }
+}

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -201,7 +201,7 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
         // original value and it becomes a copy.
         $get_display_value = function ($original_value) use ($solr_field, &$solr_fields) {
           $value = $original_value;
-          $field_config = $solr_fields[$solr_field] + array(
+          $field_config = (is_array($solr_fields[$solr_field]) ? $solr_fields[$solr_field] : array()) + array(
             'hyperlink' => 0,
             'formatter' => NULL,
           );
@@ -234,7 +234,13 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                 $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
 
                 $site = _get_site_from_config();
-                $target_sites = $target_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfSite');
+                $target_sites_rel = $target_object->relationships->get(NULL, 'isMemberOfSite');
+                $target_sites = array();
+                foreach ($target_sites_rel as $tar) {
+                  if (isset($tar['object']['value'])) {
+                    $target_sites[] = 'info:fedora/' . $tar['object']['value'];
+                  }
+                }
                 if (array_search($site, $target_sites) === FALSE) {
                   unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
                   return ;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -234,10 +234,8 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                 $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
                 if ($target_object) {
                   $use_target = 'islandora/object/' . $target_object->id;
-                  $use_value = $target_object->label;
-                } else {
-                  $use_target = '';
-                  $use_value = 'test';
+                  $use_value = ($link_options['link_text_options']['link_text_text']) ?
+                    _get_SOLR_field_value($target_object->id, $link_options['link_text_options']['link_text_text']) : $target_object->label;
                 }
               }
               if (!isset($link_options['link_target']) || $link_options['link_target'] == 'SOLR') {
@@ -326,6 +324,23 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
     else {
       return FALSE;
     }
+  }
+}
+
+/**
+ * Helper function to get a SOLR value for a given PID.
+ */
+function _get_SOLR_field_value($pid, $field) {
+  $query_processor = new IslandoraSolrQueryProcessor();
+  $query_processor->solrQuery = 'PID:"' . $pid . '"';
+  $query_processor->solrParams['fl'] = $field;
+  $query_processor->executeQuery(FALSE);
+  if ($query_processor->islandoraSolrResult['response']['numFound'] > 0) {
+    $solr_results_doc = $query_processor->islandoraSolrResult['response']['objects']['0']['solr_doc'];
+    return (!is_array($solr_results_doc[$field])) ? $solr_results_doc[$field] : $solr_results_doc[$field][0];
+  }
+  else {
+    return false;
   }
 }
 

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -232,6 +232,14 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
               $use_value = $value;
               if (isset($link_options['link_text']) && $link_options['link_text'] == 'otherfield') {
                 $target_object = islandora_object_load(str_replace('info:fedora/', '', $value));
+
+                $site = _get_site_from_config();
+                $target_sites = $target_object->relationships->get(FEDORA_RELS_EXT_URI, 'isMemberOfSite');
+                if (array_search($site, $target_sites) === FALSE) {
+                  unset($solr_fields['RELS_EXT_isMemberOfCollection_uri_ms']);
+                  return ;
+                }
+
                 if ($target_object) {
                   $use_target = 'islandora/object/' . $target_object->id;
                   $use_value = ($link_options['link_text_options']['link_text_text']) ?
@@ -326,6 +334,26 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
     }
   }
 }
+
+/** 
+ * Helper function to derive the site value from the islandora_solr_base_filter value
+ */
+function _get_site_from_config() {
+  $base_filter = variable_get('islandora_solr_base_filter');
+  // look for the value for RELS_EXT_isMemberOfSite_uri_ms 
+  $filters = explode("\r\n", $base_filter);
+  $found_filter = '';
+  foreach ($filters as $filter) { 
+    if (strstr($filter, 'RELS_EXT_isMemberOfSite_uri_ms') <> '') {
+      $found_filter = $filter;
+    }  
+  }
+  if ($found_filter) { 
+    $site = str_replace(array('"', 'RELS_EXT_isMemberOfSite_uri_ms:'), '', $found_filter);
+    return $site;
+  }
+}
+
 
 /**
  * Helper function to get a SOLR value for a given PID.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -260,8 +260,14 @@ function islandora_solr_metadata_query_fields($object, &$solr_fields) {
                   if ($site <> '' && array_search($site, $target_sites) === FALSE) {
                     return ;
                   }
-
-                  $use_target = 'islandora/object/' . $target_object->id;
+                  $use_target = (isset($link_options['link_target']) && $link_options['link_target'] == 'pathauto') ? 
+                    str_replace('%1', 
+                                str_replace("+", 
+                                            "-", 
+                                            urlencode(strtolower(trim(_get_SOLR_field_value($target_object->id, $link_options['link_target_options']['link_target_field']))))), 
+                                $link_options['link_target_options']['link_target_pattern']) : 
+                    'islandora/object/' . $target_object->id;
+ 
                   $use_value = ($link_options['link_text_options']['link_text_text']) ?
                     _get_SOLR_field_value($target_object->id, $link_options['link_text_options']['link_text_text']) : $target_object->label;
                 }


### PR DESCRIPTION
This feature was requested by our staff.  They did not want the field that displayed the matching "Collection" items as links to the SOLR search results for those collection objects.  They also wanted the text to display something that meant something to the end-user.

For example, the current code would list the Collection metadata field as:
**Collection** 
  [pitt:collection.11](#)
  [pitt:collection.159](#) 

The enhanced code will display a given field value from the object that has the relationship with the current object.  For example, displaying the dc.title field for the related Collection objects:
**Collection** 
  [Press Releases](#)
  [Pitt Administration](#) 

Also, the links now direct the user to the actual objects - eg: islandora/object/pitt:collection.11 (which is actually handled in our system by pathauto alias and Drupal turns that into something like /collection/pitt-press-releases).
